### PR TITLE
Update mock_dlt_message.py to have have mock storage timestamp

### DIFF
--- a/src/dltlyse/mock_dlt_message.py
+++ b/src/dltlyse/mock_dlt_message.py
@@ -34,3 +34,12 @@ class MockStorageHeader(object):
     def __init__(self, msec=0, sec=0):
         self.microseconds = msec
         self.seconds = sec
+
+
+class MockDLTMessageWithTime(MockDLTMessage):
+    "MockDLTMessage but with storage_timestamp"
+    
+    @property
+    def storage_timestamp(self):
+        """Fake storage timestamp"""
+        return float("{}.{}".format(self.storageheader.seconds, self.storageheader.microseconds))

--- a/src/dltlyse/mock_dlt_message.py
+++ b/src/dltlyse/mock_dlt_message.py
@@ -38,7 +38,7 @@ class MockStorageHeader(object):
 
 class MockDLTMessageWithTime(MockDLTMessage):
     "MockDLTMessage but with storage_timestamp"
-    
+
     @property
     def storage_timestamp(self):
         """Fake storage timestamp"""


### PR DESCRIPTION
Allows the capablites to have mock data which has a storage timestamp